### PR TITLE
Babel add logger feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Has now an API endpoint in index.ts which stores a log file in the directory bab
 How to:
 - import the tampermonkey script babel.typescript.highlight.words.js
 - yarn build && yarn start in windows cmd
+- open http://localhost:3000/ in browser and click on "random"
 - monitor the log file changes in powershell or Notepad++ under View and Monitoring (tail -f)
 
 # babel

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# Patch1
+
+Has now an API endpoint in index.ts which stores a log file in the directory babel-logs you have to create in the main project folder before. The fun is that it's collecting random pages & words with timestamps automatically when time passes. If you are lucky you get some meaningful results.
+
+How to:
+- import the tampermonkey script babel.typescript.highlight.words.js
+- yarn build && yarn start in windows cmd
+- monitor the log file changes in powershell or Notepad++ under View and Monitoring (tail -f)
+
 # babel
 
 A functional, complete, true-to-scale re-creation of the [Library of Babel](https://en.wikipedia.org/wiki/The_Library_of_Babel) [[.pdf](https://libraryofbabel.app/pdf/Borges-The-Library-of-Babel.pdf)].

--- a/babel.typescript.highlight.words.js
+++ b/babel.typescript.highlight.words.js
@@ -1,0 +1,63 @@
+// ==UserScript==
+// @name         Babel TypeScript Highlight Words
+// @namespace    http://tampermonkey.net/
+// @version      1.0
+// @description  Automatically clicks the highlight words button and posts the highlighted words as JSON to the API endpoint in index.ts
+// @author       robertgro
+// @match        http://localhost:3000/ref/*
+// @icon         data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🎯</text></svg>
+// @grant        none
+// ==/UserScript==
+
+(function() {
+    'use strict';
+
+    function LoadNewRandomPage() {
+        //console.log('This message is logged every 5 seconds.');
+
+        // Random Link Click
+        document.querySelector("body > nav > div > a:nth-child(3)").click();
+    }
+
+    function init() {
+        // Initialize your script
+        console.log('Script initialized');
+
+        // Click the "Highlight Words" button
+        document.querySelector("body > main > div.PageActions > button").click();
+
+        // Get the current page reference
+        const pageRef = window.location.pathname.replace("/ref/","");
+
+        var words = [];
+
+        // Wait for 5 seconds for the page to load
+        setTimeout(() => {
+            document.querySelectorAll("[data-word]").forEach((elem) => { words.push(elem.getAttribute("data-word")); });
+            console.log(words, pageRef);
+            fetch('http://localhost:3000/logdownload', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Content-Length': words.length,
+                },
+                body: JSON.stringify({words: words, pageRef: pageRef})
+            }).then((response) => {
+                console.log(response);
+                })
+        }, 5000);
+
+        //document.querySelectorAll("[data-word]").forEach((elem) => { words.push(elem.getAttribute("data-word")); });
+
+        // Must be at least 8 seconds for not so fast reloading (otherwise highlighted words can't be read)
+        // 9 seconds as default
+        setInterval(LoadNewRandomPage, 9000);
+    }
+
+    // Run when DOM is fully loaded
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();


### PR DESCRIPTION
Hi, 

at first, thanks for the efforts in creating this project.

I like to ask if a random page crawler with a [tampermonkey ](https://github.com/Tampermonkey/tampermonkey)extension script and a new API logger endpoint in ```index.ts``` is something you are interested in?

---

Entries in Notepad++ with the monitoring feature enabled are looking like this:
![image](https://github.com/user-attachments/assets/34eea59a-8fdd-4aaf-8329-d52efa7345ed)

(Timestamp + data-words found + page reference)

The browser extension script triggers the click on the "_Highlight English words_" button as well as the fetch post to the api endpoint with the JSON body payload and then the click on "_Random_" afterwards to trigger a new page load (runs endlessly until you shutdown the server or close browser tab).

---

If yes, please let me know in this PR and I'm gonna sanitize everything before you can merge the commits (it's rather a proposal now if you look at my forked readme.me)

If no, please let me know why and close this PR as unqualified feature request.

Best regards!